### PR TITLE
chore: Upgrade Tailwind CSS v3 to v4

### DIFF
--- a/.commitlintrc.js
+++ b/.commitlintrc.js
@@ -1,3 +1,3 @@
 module.exports = {
   extends: ["@commitlint/config-conventional"],
-}
+};

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,15 +1,15 @@
-import { defineConfig } from 'astro/config';
-import mdx from '@astrojs/mdx';
-import tailwind from '@astrojs/tailwind';
-import sitemap from '@astrojs/sitemap';
+import { defineConfig } from "astro/config";
+import mdx from "@astrojs/mdx";
+import tailwindcss from "@tailwindcss/vite";
+import sitemap from "@astrojs/sitemap";
 
 export default defineConfig({
-  site: 'https://queen.raae.codes',
-  trailingSlash: 'always',
+  site: "https://queen.raae.codes",
+  trailingSlash: "always",
   image: {
     // Skip processing for GIF files which can be too large
     service: {
-      entrypoint: 'astro/assets/services/sharp',
+      entrypoint: "astro/assets/services/sharp",
       config: {
         limitInputPixels: false,
       },
@@ -17,24 +17,18 @@ export default defineConfig({
   },
   integrations: [
     mdx(),
-    tailwind(),
     sitemap({
       filter: (page) => {
         // Exclude certain pages from sitemap
-        const excludedPaths = [
-          '/posts/preferences/',
-          '/posts/welcome/',
-          '/posts/reminders/',
-          '/search/',
-        ];
-        return !excludedPaths.some(path => page.includes(path)) &&
-               !page.includes('/tag/'); // Exclude tag archives
-      }
+        const excludedPaths = ["/posts/preferences/", "/posts/welcome/", "/posts/reminders/", "/search/"];
+        return !excludedPaths.some((path) => page.includes(path)) && !page.includes("/tag/"); // Exclude tag archives
+      },
     }),
   ],
   vite: {
+    plugins: [tailwindcss()],
     ssr: {
-      noExternal: ['clsx', 'date-fns'],
+      noExternal: ["clsx", "date-fns"],
     },
   },
 });

--- a/package.json
+++ b/package.json
@@ -15,19 +15,17 @@
     "@astrojs/mdx": "^4.3.13",
     "@astrojs/rss": "^4.0.15",
     "@astrojs/sitemap": "^3.7.0",
-    "@astrojs/tailwind": "^6.0.2",
-    "@tailwindcss/forms": "0.5.3",
-    "@tailwindcss/typography": "0.5.8",
+    "@tailwindcss/forms": "^0.5.11",
+    "@tailwindcss/typography": "^0.5.19",
+    "@tailwindcss/vite": "^4.1.18",
     "astro": "^5.16.15",
-    "autoprefixer": "10.4.12",
     "clsx": "1.2.1",
     "date-fns": "2.29.3",
     "markdown-it": "^14.1.0",
-    "postcss": "8.4.18",
     "prismjs": "1.29.0",
     "satori": "^0.19.1",
     "sharp": "^0.34.5",
-    "tailwindcss": "3.1.8"
+    "tailwindcss": "^4.1.18"
   },
   "devDependencies": {
     "@commitlint/cli": "^17.1.2",

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,6 +1,0 @@
-module.exports = {
-  plugins: {
-    tailwindcss: {},
-    autoprefixer: {},
-  },
-}

--- a/src/components/ContentList.astro
+++ b/src/components/ContentList.astro
@@ -35,7 +35,7 @@ const { items = [], ctas = [], class: className } = Astro.props;
             href={linkHref}
             target={isExternal ? "_blank" : undefined}
             rel={isExternal ? "noreferrer" : undefined}
-            class="text-inherit no-underline focus:outline-none"
+            class="text-inherit no-underline focus:outline-hidden"
           >
             <span class="absolute inset-0" aria-hidden="true" />
             <Fragment set:html={primary} />
@@ -68,7 +68,7 @@ const { items = [], ctas = [], class: className } = Astro.props;
           href={linkHref}
           target={isExternal ? "_blank" : undefined}
           rel={isExternal ? "noreferrer" : undefined}
-          class="w-full no-underline inline-flex items-center justify-between border-2 border-solid border-teal-800 px-4 py-2 text-sm text-teal-900 font-bold shadow-sm hover:bg-amber-400/40 focus:outline-none focus:ring-4 focus:ring-teal-500"
+          class="w-full no-underline inline-flex items-center justify-between border-2 border-solid border-teal-800 px-4 py-2 text-sm text-teal-900 font-bold shadow-xs hover:bg-amber-400/40 focus:outline-hidden focus:ring-4 focus:ring-teal-500"
         >
           {label}
           {isExternal && (

--- a/src/components/CtaButton.astro
+++ b/src/components/CtaButton.astro
@@ -16,7 +16,7 @@ const isExternal = Boolean(href);
   target={isExternal ? "_blank" : undefined}
   rel={isExternal ? "noreferrer" : undefined}
   class:list={[
-    "no-underline inline-flex items-center justify-between border-2 border-solid border-teal-800 px-4 py-2 text-sm text-teal-900 font-bold shadow-sm hover:bg-amber-400/40 focus:outline-none focus:ring-4 focus:ring-teal-500",
+    "no-underline inline-flex items-center justify-between border-2 border-solid border-teal-800 px-4 py-2 text-sm text-teal-900 font-bold shadow-xs hover:bg-amber-400/40 focus:outline-hidden focus:ring-4 focus:ring-teal-500",
     className
   ]}
 >

--- a/src/components/Newsletter.astro
+++ b/src/components/Newsletter.astro
@@ -85,13 +85,13 @@ const emailId = `email-${crypto.randomUUID().slice(0, 8)}`;
       id={emailId}
       name="email"
       type="email"
-      class="pl-11 font-medium w-full flex-grow border-solid transition border-2 border-teal-900 focus:border-teal-900 focus-within:ring-2 focus-within:ring-offset-2 focus-within:ring-amber-500"
+      class="pl-11 font-medium w-full grow border-solid transition border-2 border-teal-900 focus:border-teal-900 focus-within:ring-2 focus-within:ring-offset-2 focus-within:ring-amber-500"
       placeholder="Your best email"
       required
     />
 
     <button
-      class="ml-3 transition flex-shrink-0 text-sm font-semibold px-3 justify-center border border-transparent bg-teal-900 text-white hover:bg-teal-800 focus:outline-none focus:ring-2 focus:ring-amber-500 focus:ring-offset-2"
+      class="ml-3 transition shrink-0 text-sm font-semibold px-3 justify-center border border-transparent bg-teal-900 text-white hover:bg-teal-800 focus:outline-hidden focus:ring-2 focus:ring-amber-500 focus:ring-offset-2"
       type="submit"
     >
       {cta}

--- a/src/components/PageSection.astro
+++ b/src/components/PageSection.astro
@@ -10,7 +10,7 @@ const Tag = component as any;
 ---
 
 <Tag class:list={["py-12 px-6 bg-[#fffaf0] even:bg-[#fcedd8]", className]} id={id}>
-  <div class="container mx-auto max-w-2xl [&>*]:max-w-xl">
+  <div class="container mx-auto max-w-2xl *:max-w-xl">
     <slot />
   </div>
 </Tag>

--- a/src/components/SiteHeader.astro
+++ b/src/components/SiteHeader.astro
@@ -24,7 +24,7 @@ function getSocialIcon(url: string) {
 
       <a
         href="/search/"
-        class="[&>*]:h-5 [&>*]:w-5 translate-y-px hover:scale-110 transition-transform mr-4"
+        class="*:h-5 *:w-5 translate-y-px hover:scale-110 transition-transform mr-4"
       >
         <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="20px" height="20px" class="h-5 w-5">
           <path fill="#dadcec" d="M40.78 41.46H46.32V45.46H40.78z" transform="rotate(-45 43.543 43.464)"/>
@@ -50,7 +50,7 @@ function getSocialIcon(url: string) {
             href={url}
             target="_blank"
             rel="noreferrer"
-            class="[&>*]:h-6 [&>*]:w-6 hover:scale-110 transition-transform"
+            class="*:h-6 *:w-6 hover:scale-110 transition-transform"
           >
             {iconType === 'github' && (
               <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="24px" height="24px" class="h-6 w-6">

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -1,4 +1,4 @@
-import { defineCollection, z } from 'astro:content';
+import { defineCollection, z } from "astro:content";
 
 // Schema for tags - extracted from comma-separated string
 const tagSchema = z.object({
@@ -8,7 +8,7 @@ const tagSchema = z.object({
 
 // Posts collection (combines posts-queen and posts-olavea)
 const postsQueen = defineCollection({
-  type: 'content',
+  type: "content",
   schema: z.object({
     title: z.string(),
     emojii: z.string().optional(),
@@ -20,7 +20,7 @@ const postsQueen = defineCollection({
 });
 
 const postsOlavea = defineCollection({
-  type: 'content',
+  type: "content",
   schema: z.object({
     title: z.string(),
     emojii: z.string().optional(),
@@ -33,122 +33,152 @@ const postsOlavea = defineCollection({
 
 // Landing pages collection
 const landing = defineCollection({
-  type: 'content',
-  schema: ({ image }) => z.object({
-    badge: z.string().optional(),
-    title: z.string().optional(),
-    lead: z.string().optional(),
-    tagline: z.string().optional(),
-    imageAlt: z.string().optional(),
-    image: image().optional(),
-    seo: z.object({
-      title: z.string().optional(),
-      description: z.string().optional(),
-      imageAlt: z.string().optional(),
-      image: image().optional(),
-    }).optional(),
-    cta: z.object({
-      href: z.string().optional(),
-      label: z.string().optional(),
-      noteTitle: z.string().optional(),
-      note: z.string().optional(),
-    }).optional(),
-    ctas: z.array(z.object({
-      to: z.string().optional(),
-      label: z.string().optional(),
-    })).optional(),
-    webinar: z.object({
-      date: z.any().optional(),
-      url: z.string().optional(),
-    }).optional(),
-    form: z.object({
-      cta: z.string().optional(),
-      key: z.string().optional(),
-      message: z.string().optional(),
-      tagline: z.string().optional(),
-    }).optional(),
-    join: z.object({
-      start: z.union([z.string(), z.date()]).optional(),
-      end: z.union([z.string(), z.date()]).optional(),
-      deadline: z.union([z.string(), z.number()]).optional(),
-      paymentLink: z.string().optional(),
-      price: z.string().optional(),
-      status: z.string().optional(),
-    }).optional(),
-    sections: z.array(z.object({
-      element: z.string().optional(),
+  type: "content",
+  schema: ({ image }) =>
+    z.object({
       badge: z.string().optional(),
       title: z.string().optional(),
-      titlePath: z.string().optional(),
       lead: z.string().optional(),
       tagline: z.string().optional(),
-      content: z.string().optional(),
       imageAlt: z.string().optional(),
       image: image().optional(),
-      body: z.string().optional(), // Path to body markdown file
-      testimonials: z.array(z.string()).optional(), // Paths to testimonial files
-    })).optional(),
-  }),
+      seo: z
+        .object({
+          title: z.string().optional(),
+          description: z.string().optional(),
+          imageAlt: z.string().optional(),
+          image: image().optional(),
+        })
+        .optional(),
+      cta: z
+        .object({
+          href: z.string().optional(),
+          label: z.string().optional(),
+          noteTitle: z.string().optional(),
+          note: z.string().optional(),
+        })
+        .optional(),
+      ctas: z
+        .array(
+          z.object({
+            to: z.string().optional(),
+            label: z.string().optional(),
+          })
+        )
+        .optional(),
+      webinar: z
+        .object({
+          date: z.any().optional(),
+          url: z.string().optional(),
+        })
+        .optional(),
+      form: z
+        .object({
+          cta: z.string().optional(),
+          key: z.string().optional(),
+          message: z.string().optional(),
+          tagline: z.string().optional(),
+        })
+        .optional(),
+      join: z
+        .object({
+          start: z.union([z.string(), z.date()]).optional(),
+          end: z.union([z.string(), z.date()]).optional(),
+          deadline: z.union([z.string(), z.number()]).optional(),
+          paymentLink: z.string().optional(),
+          price: z.string().optional(),
+          status: z.string().optional(),
+        })
+        .optional(),
+      sections: z
+        .array(
+          z.object({
+            element: z.string().optional(),
+            badge: z.string().optional(),
+            title: z.string().optional(),
+            titlePath: z.string().optional(),
+            lead: z.string().optional(),
+            tagline: z.string().optional(),
+            content: z.string().optional(),
+            imageAlt: z.string().optional(),
+            image: image().optional(),
+            body: z.string().optional(), // Path to body markdown file
+            testimonials: z.array(z.string()).optional(), // Paths to testimonial files
+          })
+        )
+        .optional(),
+    }),
 });
 
 // Talks collection
 const talks = defineCollection({
-  type: 'content',
-  schema: ({ image }) => z.object({
-    badge: z.string().optional(),
-    title: z.string().optional(),
-    lead: z.string().optional(),
-    event: z.string().optional(),
-    eventUrl: z.string().optional(),
-    recording: z.string().optional(),
-    imageAlt: z.string().optional(),
-    image: image().optional(),
-    archive: z.object({
-      title: z.string().optional(),
-      more: z.string().optional(),
-      moreHref: z.string().optional(),
-    }).optional(),
-    teaser: z.object({
+  type: "content",
+  schema: ({ image }) =>
+    z.object({
       badge: z.string().optional(),
       title: z.string().optional(),
+      lead: z.string().optional(),
+      event: z.string().optional(),
+      eventUrl: z.string().optional(),
       recording: z.string().optional(),
-      note: z.string().optional(),
-    }).optional(),
-    cta: z.object({
-      label: z.string().optional(),
-      href: z.string().optional(),
-      noteTitle: z.string().optional(),
-      note: z.string().optional(),
-    }).optional(),
-  }),
+      imageAlt: z.string().optional(),
+      image: image().optional(),
+      archive: z
+        .object({
+          title: z.string().optional(),
+          more: z.string().optional(),
+          moreHref: z.string().optional(),
+        })
+        .optional(),
+      teaser: z
+        .object({
+          badge: z.string().optional(),
+          title: z.string().optional(),
+          recording: z.string().optional(),
+          note: z.string().optional(),
+        })
+        .optional(),
+      cta: z
+        .object({
+          label: z.string().optional(),
+          href: z.string().optional(),
+          noteTitle: z.string().optional(),
+          note: z.string().optional(),
+        })
+        .optional(),
+    }),
 });
 
 // Tags collection (YAML files) - array of tag objects
 const tags = defineCollection({
-  type: 'data',
-  schema: z.array(z.object({
-    label: z.string(),
-    disclaimer: z.string().optional(),
-  })),
+  type: "data",
+  schema: z.array(
+    z.object({
+      label: z.string(),
+      disclaimer: z.string().optional(),
+    })
+  ),
 });
 
 // Testimonials collection (YAML files)
 const testimonials = defineCollection({
-  type: 'data',
-  schema: z.array(z.object({
-    url: z.string().optional(),
-    post: z.string().optional(),
-    image: z.string().optional(),
-    product: z.string().optional(),
-    date: z.union([z.string(), z.date()]).optional(),
-  })),
+  type: "data",
+  schema: z.array(
+    z.object({
+      url: z.string().optional(),
+      post: z.string().optional(),
+      image: z.string().optional(),
+      product: z.string().optional(),
+      date: z.union([z.string(), z.date()]).optional(),
+    })
+  ),
 });
 
 export const collections = {
-  'posts-queen': postsQueen,
-  'posts-olavea': postsOlavea,
-  'landing': landing,
-  'talks': talks,
-  'tags': tags,
-  'testimonials': testimonials,
+  "posts-queen": postsQueen,
+  "posts-olavea": postsOlavea,
+  landing: landing,
+  talks: talks,
+  tags: tags,
+  testimonials: testimonials,
 };

--- a/src/data/siteMetadata.js
+++ b/src/data/siteMetadata.js
@@ -1,15 +1,12 @@
 export default {
-  siteUrl: 'https://queen.raae.codes',
-  siteName: 'Queen Raae',
-  siteTagline: 'Sailing the high seas of the World Wide Web',
-  siteDescription: 'Ahoy, seasoned JavaScript developers and daring dev pirates! Join our swashbuckling crew as we embark on thrilling treasure hunts unraveling the secrets of HTML, CSS, and JavaScript, all while having a blast!',
-  siteLang: 'en',
-  siteSocialImage: '/raae.jpg',
-  siteSocialImageAlt: 'Queen Raae holding a laptop in front of her gallery wall',
-  siteTwitterCreator: '@raae',
-  siteSocialMedia: [
-    'https://github.com/queen-raae',
-    'https://twitter.com/raae',
-    'https://www.youtube.com/QueenRaae',
-  ],
+  siteUrl: "https://queen.raae.codes",
+  siteName: "Queen Raae",
+  siteTagline: "Sailing the high seas of the World Wide Web",
+  siteDescription:
+    "Ahoy, seasoned JavaScript developers and daring dev pirates! Join our swashbuckling crew as we embark on thrilling treasure hunts unraveling the secrets of HTML, CSS, and JavaScript, all while having a blast!",
+  siteLang: "en",
+  siteSocialImage: "/raae.jpg",
+  siteSocialImageAlt: "Queen Raae holding a laptop in front of her gallery wall",
+  siteTwitterCreator: "@raae",
+  siteSocialMedia: ["https://github.com/queen-raae", "https://twitter.com/raae", "https://www.youtube.com/QueenRaae"],
 };

--- a/src/global.css
+++ b/src/global.css
@@ -1,9 +1,43 @@
 /* PrismJS theme for code highlighting */
-@import 'prismjs/themes/prism-solarizedlight.css';
+@import 'prismjs/themes/prism-solarizedlight.css' layer(base);
 
-@tailwind base;
-@tailwind components;
-@tailwind utilities;
+@import 'tailwindcss';
+
+@plugin "@tailwindcss/forms";
+@plugin "@tailwindcss/typography";
+
+@config '../tailwind.config.js';
+
+@theme {
+  --color-brown-50: #fbf6f5;
+  --color-brown-100: #f6ecea;
+  --color-brown-200: #f0dcd8;
+  --color-brown-300: #e4c3bd;
+  --color-brown-400: #d2a097;
+  --color-brown-500: #bf7f74;
+  --color-brown-600: #a96559;
+  --color-brown-700: #8d5248;
+  --color-brown-800: #76463e;
+  --color-brown-900: #3e2723;
+}
+
+/*
+  The default border color has changed to `currentcolor` in Tailwind CSS v4,
+  so we've added these compatibility styles to make sure everything still
+  looks the same as it did with Tailwind CSS v3.
+
+  If we ever want to remove these styles, we need to add an explicit border
+  color utility to any element that depends on these defaults.
+*/
+@layer base {
+  *,
+  ::after,
+  ::before,
+  ::backdrop,
+  ::file-selector-button {
+    border-color: var(--color-gray-200, currentcolor);
+  }
+}
 
 .notice {
   @apply border-4 border-dashed border-amber-500 px-4 my-8 text-sm;

--- a/src/lib/disclaimers.ts
+++ b/src/lib/disclaimers.ts
@@ -1,11 +1,11 @@
-import { getEntry } from 'astro:content';
+import { getEntry } from "astro:content";
 
 // Load disclaimers from brands.yml and return a Map of tag label -> disclaimer text
 export async function getDisclaimers(): Promise<Map<string, string>> {
   const disclaimers = new Map<string, string>();
 
   try {
-    const brands = await getEntry('tags', 'brands');
+    const brands = await getEntry("tags", "brands");
     if (brands?.data) {
       for (const brand of brands.data) {
         if (brand.disclaimer) {

--- a/src/lib/feed.ts
+++ b/src/lib/feed.ts
@@ -1,40 +1,31 @@
-import MarkdownIt from 'markdown-it';
-import type { ProcessedPost } from './posts';
+import MarkdownIt from "markdown-it";
+import type { ProcessedPost } from "./posts";
 
 const md = new MarkdownIt();
 
 // Default emojis matching Gatsby type definitions
 const DEFAULT_EMOJII: Record<string, string> = {
-  Queen: '📝 ✨',
-  OlaVea: '⛵ 🔧',
+  Queen: "📝 ✨",
+  OlaVea: "⛵ 🔧",
 };
 
 export function makeAbsolute(html: string, siteUrl: string): string {
-  const base = siteUrl.replace(/\/$/, '');
+  const base = siteUrl.replace(/\/$/, "");
   return html
     .replace(/(?<=["|\s])\/static\//g, `${base}/static/`)
     .replace(/(?<=["|\s])\/emails\//g, `${base}/emails/`)
     .replace(/(?<=["|\s])\/posts\//g, `${base}/posts/`);
 }
 
-export function getPostDisclaimers(
-  post: { tags: { label: string }[] },
-  disclaimers: Map<string, string>
-): string[] {
-  return post.tags
-    .map((tag) => disclaimers.get(tag.label))
-    .filter((d): d is string => !!d);
+export function getPostDisclaimers(post: { tags: { label: string }[] }, disclaimers: Map<string, string>): string[] {
+  return post.tags.map((tag) => disclaimers.get(tag.label)).filter((d): d is string => !!d);
 }
 
 export function getEmojii(post: ProcessedPost): string {
-  return post.emojii || DEFAULT_EMOJII[post.author] || '';
+  return post.emojii || DEFAULT_EMOJII[post.author] || "";
 }
 
-export function postToFeedItem(
-  post: ProcessedPost,
-  disclaimers: Map<string, string>,
-  siteUrl: string
-) {
+export function postToFeedItem(post: ProcessedPost, disclaimers: Map<string, string>, siteUrl: string) {
   const postDisclaimers = getPostDisclaimers(post, disclaimers);
   const emojii = getEmojii(post);
 
@@ -42,7 +33,7 @@ export function postToFeedItem(
   let content = makeAbsolute(md.render(post.content), siteUrl);
 
   if (postDisclaimers.length > 0) {
-    content += `<br/><ul>${postDisclaimers.map((d) => `<li>${d}</li>`).join('')}</ul>`;
+    content += `<br/><ul>${postDisclaimers.map((d) => `<li>${d}</li>`).join("")}</ul>`;
   }
 
   return {

--- a/src/lib/og-image.ts
+++ b/src/lib/og-image.ts
@@ -100,10 +100,7 @@ export function getOgImagePath(slug: string): string {
 
 // ── Cache-busting URL (hash changes when title/description change) ─
 export function getOgImageUrl(slug: string, title: string, description: string): string {
-  const hash = createHash("md5")
-    .update(`${title}|${description}`)
-    .digest("hex")
-    .slice(0, 8);
+  const hash = createHash("md5").update(`${title}|${description}`).digest("hex").slice(0, 8);
   return `${getOgImagePath(slug)}?v=${hash}`;
 }
 

--- a/src/lib/posts.ts
+++ b/src/lib/posts.ts
@@ -1,32 +1,35 @@
-import { getCollection } from 'astro:content';
-import { format } from 'date-fns';
+import { getCollection } from "astro:content";
+import { format } from "date-fns";
 
 // Slugify function similar to @sindresorhus/slugify
 function slugify(str: string): string {
   return str
     .toLowerCase()
     .trim()
-    .replace(/[^\w\s-]/g, '')
-    .replace(/[\s_-]+/g, '-')
-    .replace(/^-+|-+$/g, '');
+    .replace(/[^\w\s-]/g, "")
+    .replace(/[\s_-]+/g, "-")
+    .replace(/^-+|-+$/g, "");
 }
 
 // Parse comma-separated tags string into array of tag objects
-function parseTags(tagsStr: string | undefined, brandsStr?: string, peepsStr?: string, projectsStr?: string): { label: string; slug: string }[] {
-  const allTags = [tagsStr, brandsStr, peepsStr, projectsStr]
-    .filter(Boolean)
-    .join(',');
+function parseTags(
+  tagsStr: string | undefined,
+  brandsStr?: string,
+  peepsStr?: string,
+  projectsStr?: string
+): { label: string; slug: string }[] {
+  const allTags = [tagsStr, brandsStr, peepsStr, projectsStr].filter(Boolean).join(",");
 
   if (!allTags) return [];
 
   const tags = allTags
-    .split(',')
-    .map(tag => tag.trim().toLowerCase())
-    .filter(tag => tag.length > 0);
+    .split(",")
+    .map((tag) => tag.trim().toLowerCase())
+    .filter((tag) => tag.length > 0);
 
   const uniqueTags = [...new Set(tags)];
 
-  return uniqueTags.map(tag => ({
+  return uniqueTags.map((tag) => ({
     label: tag,
     slug: `/tag/${slugify(tag)}/`,
   }));
@@ -45,7 +48,7 @@ function parsePostPath(id: string): { date: string; slug: string } {
     return { date, slug };
   }
 
-  return { date: '', slug: '' };
+  return { date: "", slug: "" };
 }
 
 export interface ProcessedPost {
@@ -66,47 +69,42 @@ export interface ProcessedPost {
 
 // Get all posts from both queen and olavea collections
 export async function getAllPosts(): Promise<ProcessedPost[]> {
-  const queenPosts = await getCollection('posts-queen');
-  const olaveaPosts = await getCollection('posts-olavea');
+  const queenPosts = await getCollection("posts-queen");
+  const olaveaPosts = await getCollection("posts-olavea");
 
   const processPost = (entry: any, author: string): ProcessedPost => {
     const { date, slug } = parsePostPath(entry.id);
-    const tags = parseTags(
-      entry.data.tags,
-      entry.data.brands,
-      entry.data.peeps,
-      entry.data.projects
-    );
+    const tags = parseTags(entry.data.tags, entry.data.brands, entry.data.peeps, entry.data.projects);
 
-    const title = entry.data.title || '';
-    const isRelatable = !title.includes('week around the Gatsby islands');
+    const title = entry.data.title || "";
+    const isRelatable = !title.includes("week around the Gatsby islands");
 
     // Generate description from body content (excerpt), matching Gatsby's behavior
-    const body = entry.body || '';
+    const body = entry.body || "";
     const plainText = body
-      .replace(/^---[\s\S]*?---\s*/m, '') // Remove frontmatter if present
-      .replace(/!\[.*?\]\(.*?\)/g, '') // Remove images
-      .replace(/\[([^\]]*)\]\([^)]*\)/g, '$1') // Replace links with text
-      .replace(/#{1,6}\s+/g, '') // Remove headings
-      .replace(/[*_~`>]/g, '') // Remove emphasis markers
-      .replace(/\n+/g, ' ') // Replace newlines with spaces
-      .replace(/\s+/g, ' ') // Collapse whitespace
+      .replace(/^---[\s\S]*?---\s*/m, "") // Remove frontmatter if present
+      .replace(/!\[.*?\]\(.*?\)/g, "") // Remove images
+      .replace(/\[([^\]]*)\]\([^)]*\)/g, "$1") // Replace links with text
+      .replace(/#{1,6}\s+/g, "") // Remove headings
+      .replace(/[*_~`>]/g, "") // Remove emphasis markers
+      .replace(/\n+/g, " ") // Replace newlines with spaces
+      .replace(/\s+/g, " ") // Collapse whitespace
       .trim();
     // Gatsby's pruneLength is 160 and truncates at word boundary
     let description = plainText;
     if (plainText.length > 160) {
       const truncated = plainText.substring(0, 160);
-      const lastSpace = truncated.lastIndexOf(' ');
-      description = (lastSpace > 0 ? truncated.substring(0, lastSpace) : truncated) + '\u2026';
+      const lastSpace = truncated.lastIndexOf(" ");
+      description = (lastSpace > 0 ? truncated.substring(0, lastSpace) : truncated) + "\u2026";
     }
 
-    let dateFormatted = '';
+    let dateFormatted = "";
     let dateISO = date;
 
     if (date) {
       try {
         const dateObj = new Date(date);
-        dateFormatted = format(dateObj, 'MMMM do, yyyy');
+        dateFormatted = format(dateObj, "MMMM do, yyyy");
         dateISO = dateObj.toISOString();
       } catch (e) {
         dateFormatted = date;
@@ -117,7 +115,7 @@ export async function getAllPosts(): Promise<ProcessedPost[]> {
       id: entry.id,
       slug,
       title,
-      emojii: entry.data.emojii || '',
+      emojii: entry.data.emojii || "",
       description,
       date,
       dateFormatted,
@@ -125,14 +123,14 @@ export async function getAllPosts(): Promise<ProcessedPost[]> {
       author,
       tags,
       isRelatable,
-      content: entry.body || '',
+      content: entry.body || "",
       render: entry.render.bind(entry),
     };
   };
 
   const allPosts = [
-    ...queenPosts.map(p => processPost(p, 'Queen')),
-    ...olaveaPosts.map(p => processPost(p, 'OlaVea')),
+    ...queenPosts.map((p) => processPost(p, "Queen")),
+    ...olaveaPosts.map((p) => processPost(p, "OlaVea")),
   ];
 
   // Sort by slug descending (which is date-based)
@@ -142,7 +140,7 @@ export async function getAllPosts(): Promise<ProcessedPost[]> {
 // Get a single post by slug
 export async function getPostBySlug(slug: string): Promise<ProcessedPost | undefined> {
   const allPosts = await getAllPosts();
-  return allPosts.find(post => post.slug === slug);
+  return allPosts.find((post) => post.slug === slug);
 }
 
 // Get related posts for a given post
@@ -153,17 +151,15 @@ export function getRelatedPosts(
   titleThreshold: number = 0.7
 ): ProcessedPost[] {
   const relatedPosts = allPosts
-    .filter(post => post.slug !== currentPost.slug && post.isRelatable)
-    .map(post => {
+    .filter((post) => post.slug !== currentPost.slug && post.isRelatable)
+    .map((post) => {
       // Count intersecting tags
-      const intersectingTags = currentPost.tags.filter(
-        t1 => post.tags.some(t2 => t2.slug === t1.slug)
-      );
+      const intersectingTags = currentPost.tags.filter((t1) => post.tags.some((t2) => t2.slug === t1.slug));
 
       // Simple title similarity (word overlap)
-      const currentWords = currentPost.title.toLowerCase().replace('gatsby', '').split(/\s+/);
+      const currentWords = currentPost.title.toLowerCase().replace("gatsby", "").split(/\s+/);
       const postWords = post.title.toLowerCase().split(/\s+/);
-      const commonWords = currentWords.filter(w => postWords.includes(w) && w.length > 3);
+      const commonWords = currentWords.filter((w) => postWords.includes(w) && w.length > 3);
       const titleScore = commonWords.length / Math.max(currentWords.length, postWords.length);
 
       const titleSimilarity = titleScore > titleThreshold ? titleScore : 0;
@@ -171,7 +167,7 @@ export function getRelatedPosts(
 
       return { ...post, similarity };
     })
-    .filter(post => post.similarity > 0)
+    .filter((post) => post.similarity > 0)
     .sort((a, b) => b.similarity - a.similarity)
     .slice(0, limit);
 
@@ -183,8 +179,8 @@ export async function getAllTags(): Promise<Map<string, { label: string; slug: s
   const allPosts = await getAllPosts();
   const tagsMap = new Map<string, { label: string; slug: string; posts: ProcessedPost[] }>();
 
-  allPosts.forEach(post => {
-    post.tags.forEach(tag => {
+  allPosts.forEach((post) => {
+    post.tags.forEach((tag) => {
       if (!tagsMap.has(tag.slug)) {
         tagsMap.set(tag.slug, { ...tag, posts: [] });
       }

--- a/src/pages/og/[...slug].png.ts
+++ b/src/pages/og/[...slug].png.ts
@@ -1,12 +1,12 @@
-import type { APIRoute, GetStaticPaths } from 'astro';
-import { getAllPosts } from '../../lib/posts';
-import { generateOgImage } from '../../lib/og-image';
+import type { APIRoute, GetStaticPaths } from "astro";
+import { getAllPosts } from "../../lib/posts";
+import { generateOgImage } from "../../lib/og-image";
 
 export const getStaticPaths: GetStaticPaths = async () => {
   const allPosts = await getAllPosts();
 
   return allPosts.map((post) => {
-    const slugParam = post.slug.replace(/^\/|\/$/g, '');
+    const slugParam = post.slug.replace(/^\/|\/$/g, "");
     return {
       params: { slug: slugParam },
       props: {
@@ -24,6 +24,6 @@ export const GET: APIRoute = async ({ props }) => {
   const png = await generateOgImage({ title, description, author });
 
   return new Response(png, {
-    headers: { 'Content-Type': 'image/png' },
+    headers: { "Content-Type": "image/png" },
   });
 };

--- a/src/pages/posts/olavea.xml.ts
+++ b/src/pages/posts/olavea.xml.ts
@@ -1,20 +1,20 @@
-import rss from '@astrojs/rss';
-import type { APIContext } from 'astro';
-import { getAllPosts } from '../../lib/posts';
-import { getDisclaimers } from '../../lib/disclaimers';
-import { postToFeedItem } from '../../lib/feed';
+import rss from "@astrojs/rss";
+import type { APIContext } from "astro";
+import { getAllPosts } from "../../lib/posts";
+import { getDisclaimers } from "../../lib/disclaimers";
+import { postToFeedItem } from "../../lib/feed";
 
 export async function GET(context: APIContext) {
   const allPosts = await getAllPosts();
-  const olaveaPosts = allPosts.filter((post) => post.author === 'OlaVea');
+  const olaveaPosts = allPosts.filter((post) => post.author === "OlaVea");
   const disclaimers = await getDisclaimers();
   const siteUrl = context.site!.toString();
 
   return rss({
     title: "Posts from Cap'n Ola",
     description:
-      'Ahoy, seasoned JavaScript developers and daring dev pirates! Join our swashbuckling crew as we embark on thrilling treasure hunts unraveling the secrets of HTML, CSS, and JavaScript, all while having a blast!',
-    site: siteUrl.replace(/\/$/, '') + '/posts/olavea',
+      "Ahoy, seasoned JavaScript developers and daring dev pirates! Join our swashbuckling crew as we embark on thrilling treasure hunts unraveling the secrets of HTML, CSS, and JavaScript, all while having a blast!",
+    site: siteUrl.replace(/\/$/, "") + "/posts/olavea",
     items: olaveaPosts.map((post) => postToFeedItem(post, disclaimers, siteUrl)),
   });
 }

--- a/src/pages/posts/queen.xml.ts
+++ b/src/pages/posts/queen.xml.ts
@@ -1,20 +1,20 @@
-import rss from '@astrojs/rss';
-import type { APIContext } from 'astro';
-import { getAllPosts } from '../../lib/posts';
-import { getDisclaimers } from '../../lib/disclaimers';
-import { postToFeedItem } from '../../lib/feed';
+import rss from "@astrojs/rss";
+import type { APIContext } from "astro";
+import { getAllPosts } from "../../lib/posts";
+import { getDisclaimers } from "../../lib/disclaimers";
+import { postToFeedItem } from "../../lib/feed";
 
 export async function GET(context: APIContext) {
   const allPosts = await getAllPosts();
-  const queenPosts = allPosts.filter((post) => post.author === 'Queen');
+  const queenPosts = allPosts.filter((post) => post.author === "Queen");
   const disclaimers = await getDisclaimers();
   const siteUrl = context.site!.toString();
 
   return rss({
-    title: 'Posts from Queen Raae',
+    title: "Posts from Queen Raae",
     description:
-      'Ahoy, seasoned JavaScript developers and daring dev pirates! Join our swashbuckling crew as we embark on thrilling treasure hunts unraveling the secrets of HTML, CSS, and JavaScript, all while having a blast!',
-    site: siteUrl.replace(/\/$/, '') + '/posts',
+      "Ahoy, seasoned JavaScript developers and daring dev pirates! Join our swashbuckling crew as we embark on thrilling treasure hunts unraveling the secrets of HTML, CSS, and JavaScript, all while having a blast!",
+    site: siteUrl.replace(/\/$/, "") + "/posts",
     items: queenPosts.map((post) => postToFeedItem(post, disclaimers, siteUrl)),
   });
 }

--- a/src/pages/posts/rss.xml.ts
+++ b/src/pages/posts/rss.xml.ts
@@ -1,8 +1,8 @@
-import rss from '@astrojs/rss';
-import type { APIContext } from 'astro';
-import { getAllPosts } from '../../lib/posts';
-import { getDisclaimers } from '../../lib/disclaimers';
-import { postToFeedItem } from '../../lib/feed';
+import rss from "@astrojs/rss";
+import type { APIContext } from "astro";
+import { getAllPosts } from "../../lib/posts";
+import { getDisclaimers } from "../../lib/disclaimers";
+import { postToFeedItem } from "../../lib/feed";
 
 export async function GET(context: APIContext) {
   const allPosts = await getAllPosts();
@@ -10,10 +10,10 @@ export async function GET(context: APIContext) {
   const siteUrl = context.site!.toString();
 
   return rss({
-    title: 'Posts from Queen Raae & Family',
+    title: "Posts from Queen Raae & Family",
     description:
-      'Ahoy, seasoned JavaScript developers and daring dev pirates! Join our swashbuckling crew as we embark on thrilling treasure hunts unraveling the secrets of HTML, CSS, and JavaScript, all while having a blast!',
-    site: siteUrl.replace(/\/$/, '') + '/posts',
+      "Ahoy, seasoned JavaScript developers and daring dev pirates! Join our swashbuckling crew as we embark on thrilling treasure hunts unraveling the secrets of HTML, CSS, and JavaScript, all while having a blast!",
+    site: siteUrl.replace(/\/$/, "") + "/posts",
     items: allPosts.map((post) => postToFeedItem(post, disclaimers, siteUrl)),
   });
 }

--- a/src/pages/search/index.astro
+++ b/src/pages/search/index.astro
@@ -31,7 +31,7 @@ const searchData = allPosts.map(post => ({
         type="search"
         name="search"
         id="search"
-        class="font-medium w-full flex-grow border-solid transition border-2 border-teal-900 focus:border-amber-500 focus-within:ring-1 focus-within:ring-amber-500"
+        class="font-medium w-full grow border-solid transition border-2 border-teal-900 focus:border-amber-500 focus-within:ring-1 focus-within:ring-amber-500"
         placeholder="Type to search..."
       />
 
@@ -48,7 +48,7 @@ const searchData = allPosts.map(post => ({
         {latestPosts.map((post) => (
           <li class="mx-2 px-5 py-3 pb-4 relative border-0 border-l-4 border-solid border-amber-500 flex flex-col transition hover:bg-amber-400/30">
             <h3 class="text-base my-0 font-bold">
-              <a href={post.slug} class="text-inherit no-underline focus:outline-none">
+              <a href={post.slug} class="text-inherit no-underline focus:outline-hidden">
                 <span class="absolute inset-0" aria-hidden="true" />
                 {post.title}
               </a>
@@ -146,7 +146,7 @@ const searchData = allPosts.map(post => ({
             return `
               <li class="mx-2 px-5 py-3 pb-4 relative border-0 border-l-4 border-solid border-amber-500 flex flex-col transition hover:bg-amber-400/30">
                 <h3 class="text-base my-0 font-bold">
-                  <a href="${item.slug}" class="text-inherit no-underline focus:outline-none">
+                  <a href="${item.slug}" class="text-inherit no-underline focus:outline-hidden">
                     <span class="absolute inset-0" aria-hidden="true"></span>
                     ${title}
                   </a>

--- a/src/services/discounts.json
+++ b/src/services/discounts.json
@@ -521,10 +521,7 @@
     "percentageOfUSA": 49,
     "discount": 51
   },
-  { "country": "Nigeria",
-    "countryCode": "NGA",
-    "discount": 80
-  },
+  { "country": "Nigeria", "countryCode": "NGA", "discount": 80 },
   {
     "country": "Ethiopia",
     "countryCode": "ETH",

--- a/src/services/github.js
+++ b/src/services/github.js
@@ -31,16 +31,13 @@ export default (repoAccessToken = process.env.GITHUB_PERSONAL_ACCESS_TOKEN) => {
     log("getRepoAccess", owner, repo, username);
 
     // https://docs.github.com/en/rest/reference/repos#check-if-a-user-is-a-repository-collaborator
-    const { status } = await githubApi.get(
-      `repos/${owner}/${repo}/collaborators/${username}`,
-      {
-        validateStatus: (status) => {
-          // 204 means the user is a collaborator
-          // 404 means the user is not a collaborator
-          return [204, 404].includes(status);
-        },
-      }
-    );
+    const { status } = await githubApi.get(`repos/${owner}/${repo}/collaborators/${username}`, {
+      validateStatus: (status) => {
+        // 204 means the user is a collaborator
+        // 404 means the user is not a collaborator
+        return [204, 404].includes(status);
+      },
+    });
 
     // TODO: Also check if invited!!
 
@@ -53,9 +50,7 @@ export default (repoAccessToken = process.env.GITHUB_PERSONAL_ACCESS_TOKEN) => {
     log("addRepoAccess", owner, repo, username);
 
     // https://docs.github.com/en/rest/reference/repos#add-a-repository-collaborator
-    const { status } = await githubApi.put(
-      `repos/${owner}/${repo}/collaborators/${username}`
-    );
+    const { status } = await githubApi.put(`repos/${owner}/${repo}/collaborators/${username}`);
 
     log("status", status);
 

--- a/src/services/stripe.js
+++ b/src/services/stripe.js
@@ -7,12 +7,7 @@ export default (stripeKey = process.env.STRIPE_SECRET_KEY) => {
     console.log("Stripe:", ...args);
   };
 
-  const createSession = async ({
-    username,
-    successUrl,
-    cancelUrl,
-    priceId,
-  }) => {
+  const createSession = async ({ username, successUrl, cancelUrl, priceId }) => {
     log("createSession", username);
 
     // Stripe docs: https://stripe.com/docs/api/checkout/sessions/create

--- a/src/templates/posts-tag-archive.js
+++ b/src/templates/posts-tag-archive.js
@@ -2,10 +2,7 @@ import React from "react";
 import { graphql } from "gatsby";
 
 import SiteHeader from "../components/site-header";
-import PageSection, {
-  PageSectionBreadcrumbs,
-  PageSectionHeader,
-} from "../components/page-section";
+import PageSection, { PageSectionBreadcrumbs, PageSectionHeader } from "../components/page-section";
 import PageHead from "../components/page-head";
 
 import { Posts } from "../components/posts";
@@ -36,10 +33,7 @@ export default function PostsPage(props) {
         <PageSection component="article">
           <PageSectionBreadcrumbs
             className="mt-4"
-            items={[
-              { label: "Posts", to: "/posts/" },
-              { label: pageContext.tagLabel },
-            ]}
+            items={[{ label: "Posts", to: "/posts/" }, { label: pageContext.tagLabel }]}
           />
           <PageSectionHeader title={title} hLevel={1} />
 
@@ -56,10 +50,7 @@ export default function PostsPage(props) {
 
 export const query = graphql`
   query TagById($tagLabel: String!) {
-    allPost(
-      sort: { slug: DESC }
-      filter: { tags: { elemMatch: { label: { eq: $tagLabel } } } }
-    ) {
+    allPost(sort: { slug: DESC }, filter: { tags: { elemMatch: { label: { eq: $tagLabel } } } }) {
       nodes {
         ...PostItemFragment
       }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,27 +1,7 @@
 /** @type {import('tailwindcss').Config} */
 module.exports = {
-  content: [
-    "./src/pages/**/*.{js,jsx,ts,tsx,astro}",
-    "./src/components/**/*.{js,jsx,ts,tsx,astro}",
-    "./src/templates/**/*.{js,jsx,ts,tsx,astro}",
-    "./src/layouts/**/*.{js,jsx,ts,tsx,astro}",
-  ],
   theme: {
     extend: {
-      colors: {
-        brown: {
-          50: "#fbf6f5",
-          100: "#f6ecea",
-          200: "#f0dcd8",
-          300: "#e4c3bd",
-          400: "#d2a097",
-          500: "#bf7f74",
-          600: "#a96559",
-          700: "#8d5248",
-          800: "#76463e",
-          900: "#3e2723",
-        },
-      },
       typography: (theme) => ({
         brown: {
           css: {
@@ -100,5 +80,4 @@ module.exports = {
       }),
     },
   },
-  plugins: [require("@tailwindcss/forms"), require("@tailwindcss/typography")],
 };


### PR DESCRIPTION
## Summary

- Upgrade Tailwind CSS from v3.1.8 to v4.1.18
- Replace `@astrojs/tailwind` integration with `@tailwindcss/vite` Vite plugin
- Migrate to CSS-first configuration: custom brown palette in `@theme`, plugins via `@plugin` directives
- Remove `postcss.config.js` and `autoprefixer` (no longer needed)
- Update renamed v4 utility classes (`shadow-xs`, `outline-hidden`, `grow`, `shrink-0`, `*:` child variant)
- Keep `tailwind.config.js` only for typography plugin customization (prose-brown variant)

## Test plan

- [x] Run `npm run dev` and visually compare homepage against live site
- [x] Check a blog post page for correct prose styling (brown color scheme, ➽ bullet markers)
- [x] Verify newsletter form styling (forms plugin)
- [x] Verify search page works correctly
- [x] Run `npm run build` — should complete with zero errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)