### PR TITLE
Move tag parsing and caching to content layer

### DIFF
--- a/src/lib/posts.ts
+++ b/src/lib/posts.ts
@@ -1,40 +1,6 @@
 import { getCollection } from "astro:content";
 import { format } from "date-fns";
 
-// Slugify function similar to @sindresorhus/slugify
-function slugify(str: string): string {
-  return str
-    .toLowerCase()
-    .trim()
-    .replace(/[^\w\s-]/g, "")
-    .replace(/[\s_-]+/g, "-")
-    .replace(/^-+|-+$/g, "");
-}
-
-// Parse comma-separated tags string into array of tag objects
-function parseTags(
-  tagsStr: string | undefined,
-  brandsStr?: string,
-  peepsStr?: string,
-  projectsStr?: string
-): { label: string; slug: string }[] {
-  const allTags = [tagsStr, brandsStr, peepsStr, projectsStr].filter(Boolean).join(",");
-
-  if (!allTags) return [];
-
-  const tags = allTags
-    .split(",")
-    .map((tag) => tag.trim().toLowerCase())
-    .filter((tag) => tag.length > 0);
-
-  const uniqueTags = [...new Set(tags)];
-
-  return uniqueTags.map((tag) => ({
-    label: tag,
-    slug: `/tag/${slugify(tag)}/`,
-  }));
-}
-
 // Parse date and slug from post path
 // Pattern: /2022/03/17-demo/index.md -> date: 2022-03-17, slug: /2022-03-17-demo/
 function parsePostPath(id: string): { date: string; slug: string } {
@@ -67,66 +33,74 @@ export interface ProcessedPost {
   render: () => Promise<{ Content: any }>;
 }
 
+// Process a single collection entry into a ProcessedPost.
+// Tags and isRelatable are pre-computed by the schema transform in config.ts.
+function processPost(entry: any, author: string): ProcessedPost {
+  const { date, slug } = parsePostPath(entry.id);
+
+  const title = entry.data.title || "";
+
+  // Generate description from body content (excerpt), matching Gatsby's behavior
+  const body = entry.body || "";
+  const plainText = body
+    .replace(/^---[\s\S]*?---\s*/m, "") // Remove frontmatter if present
+    .replace(/!\[.*?\]\(.*?\)/g, "") // Remove images
+    .replace(/\[([^\]]*)\]\([^)]*\)/g, "$1") // Replace links with text
+    .replace(/#{1,6}\s+/g, "") // Remove headings
+    .replace(/[*_~`>]/g, "") // Remove emphasis markers
+    .replace(/\n+/g, " ") // Replace newlines with spaces
+    .replace(/\s+/g, " ") // Collapse whitespace
+    .trim();
+  // Gatsby's pruneLength is 160 and truncates at word boundary
+  let description = plainText;
+  if (plainText.length > 160) {
+    const truncated = plainText.substring(0, 160);
+    const lastSpace = truncated.lastIndexOf(" ");
+    description = (lastSpace > 0 ? truncated.substring(0, lastSpace) : truncated) + "\u2026";
+  }
+
+  let dateFormatted = "";
+  let dateISO = date;
+
+  if (date) {
+    try {
+      const dateObj = new Date(date);
+      dateFormatted = format(dateObj, "MMMM do, yyyy");
+      dateISO = dateObj.toISOString();
+    } catch (e) {
+      dateFormatted = date;
+    }
+  }
+
+  return {
+    id: entry.id,
+    slug,
+    title,
+    emojii: entry.data.emojii || "",
+    description,
+    date,
+    dateFormatted,
+    dateISO,
+    author,
+    tags: entry.data.tags || [],
+    isRelatable: entry.data.isRelatable ?? true,
+    content: entry.body || "",
+    render: entry.render.bind(entry),
+  };
+}
+
+// Module-level cache: getAllPosts() is called from many pages during a build.
+// The content layer caches the raw collection data and schema transforms;
+// this cache prevents re-running processPost() (excerpt generation, date
+// formatting) on every call within a single build.
+let _cachedPosts: ProcessedPost[] | null = null;
+
 // Get all posts from both queen and olavea collections
 export async function getAllPosts(): Promise<ProcessedPost[]> {
+  if (_cachedPosts) return _cachedPosts;
+
   const queenPosts = await getCollection("posts-queen");
   const olaveaPosts = await getCollection("posts-olavea");
-
-  const processPost = (entry: any, author: string): ProcessedPost => {
-    const { date, slug } = parsePostPath(entry.id);
-    const tags = parseTags(entry.data.tags, entry.data.brands, entry.data.peeps, entry.data.projects);
-
-    const title = entry.data.title || "";
-    const isRelatable = !title.includes("week around the Gatsby islands");
-
-    // Generate description from body content (excerpt), matching Gatsby's behavior
-    const body = entry.body || "";
-    const plainText = body
-      .replace(/^---[\s\S]*?---\s*/m, "") // Remove frontmatter if present
-      .replace(/!\[.*?\]\(.*?\)/g, "") // Remove images
-      .replace(/\[([^\]]*)\]\([^)]*\)/g, "$1") // Replace links with text
-      .replace(/#{1,6}\s+/g, "") // Remove headings
-      .replace(/[*_~`>]/g, "") // Remove emphasis markers
-      .replace(/\n+/g, " ") // Replace newlines with spaces
-      .replace(/\s+/g, " ") // Collapse whitespace
-      .trim();
-    // Gatsby's pruneLength is 160 and truncates at word boundary
-    let description = plainText;
-    if (plainText.length > 160) {
-      const truncated = plainText.substring(0, 160);
-      const lastSpace = truncated.lastIndexOf(" ");
-      description = (lastSpace > 0 ? truncated.substring(0, lastSpace) : truncated) + "\u2026";
-    }
-
-    let dateFormatted = "";
-    let dateISO = date;
-
-    if (date) {
-      try {
-        const dateObj = new Date(date);
-        dateFormatted = format(dateObj, "MMMM do, yyyy");
-        dateISO = dateObj.toISOString();
-      } catch (e) {
-        dateFormatted = date;
-      }
-    }
-
-    return {
-      id: entry.id,
-      slug,
-      title,
-      emojii: entry.data.emojii || "",
-      description,
-      date,
-      dateFormatted,
-      dateISO,
-      author,
-      tags,
-      isRelatable,
-      content: entry.body || "",
-      render: entry.render.bind(entry),
-    };
-  };
 
   const allPosts = [
     ...queenPosts.map((p) => processPost(p, "Queen")),
@@ -134,7 +108,8 @@ export async function getAllPosts(): Promise<ProcessedPost[]> {
   ];
 
   // Sort by slug descending (which is date-based)
-  return allPosts.sort((a, b) => b.slug.localeCompare(a.slug));
+  _cachedPosts = allPosts.sort((a, b) => b.slug.localeCompare(a.slug));
+  return _cachedPosts;
 }
 
 // Get a single post by slug


### PR DESCRIPTION
## Summary
Refactored tag processing and post caching to leverage Astro's content layer, improving build performance and reducing runtime computation.

## Key Changes
- **Moved tag parsing to schema transform**: Migrated `slugify()` and `parseTags()` functions from `src/lib/posts.ts` to `src/content/config.ts` where they're now executed during content collection, allowing Astro to cache the results
- **Unified post schema**: Both `posts-queen` and `posts-olavea` collections now share a single `postSchema` definition with a `.transform()` that pre-computes `tags` and `isRelatable` fields
- **Added module-level caching**: Implemented `_cachedPosts` cache in `getAllPosts()` to prevent re-running excerpt generation and date formatting on repeated calls within a single build
- **Simplified post processing**: The `processPost()` function now reads pre-computed `tags` and `isRelatable` from `entry.data` instead of deriving them at runtime

## Implementation Details
- The schema transform converts comma-separated tag strings (from `tags`, `brands`, `peeps`, `projects` fields) into a unified array of tag objects with `label` and `slug` properties
- Tag slugs are generated with the format `/tag/{slugified-name}/`
- The `isRelatable` field is computed based on whether the post title contains "week around the Gatsby islands"
- Caching is transparent to callers—`getAllPosts()` returns the same result on subsequent calls within a build

https://claude.ai/code/session_013a4j9AGUT2SgQTz2GTWNRN