### PR TITLE
Simplify Posts component by removing detailed variant

### DIFF
--- a/src/components/Posts.astro
+++ b/src/components/Posts.astro
@@ -1,41 +1,23 @@
 ---
 import ContentList from './ContentList.astro';
-import Badge from './Badge.astro';
 import type { ProcessedPost } from '../lib/posts';
 
 interface Props {
   posts?: ProcessedPost[];
   more?: boolean;
-  variant?: 'default' | 'detailed';
   limit?: number;
   class?: string;
 }
 
-const { posts = [], more = false, variant = 'default', limit, class: className } = Astro.props;
+const { posts = [], more = false, limit, class: className } = Astro.props;
 
 const displayPosts = limit ? posts.slice(0, limit) : posts;
 
-const items = displayPosts.map(({ title, description, slug, dateFormatted, tags }) => {
-  let body = '';
-
-  if (variant === 'detailed') {
-    const tagBadges = tags.map(({ label }) =>
-      `<span class="inline-flex items-center rounded-md px-2.5 py-0.5 border-style bg-amber-100 text-xs font-medium text-brown-900">${label}</span>`
-    ).join(' ');
-
-    body = `
-      <p class="my-2 text-sm">${description}</p>
-      <aside class="my-0 space-x-2">${tagBadges}</aside>
-    `;
-  }
-
-  return {
-    to: slug,
-    primary: title,
-    body: variant === 'detailed' ? body : undefined,
-    secondary: dateFormatted,
-  };
-});
+const items = displayPosts.map(({ title, slug, dateFormatted }) => ({
+  to: slug,
+  primary: title,
+  secondary: dateFormatted,
+}));
 
 const ctas = more ? [{ to: '/posts/', label: 'More...' }] : [];
 ---


### PR DESCRIPTION
## Summary
Removed the `variant` prop and associated detailed view functionality from the Posts component, simplifying it to a single, streamlined display mode.

## Changes
- Removed `variant` prop ('default' | 'detailed') from component interface
- Removed Badge component import (no longer needed)
- Simplified post item mapping to only include title, slug, and formatted date
- Removed conditional rendering logic for detailed view with descriptions and tag badges
- Reduced component complexity and bundle size

## Details
The detailed variant included inline HTML generation for tag badges and description text. This functionality has been completely removed, leaving only the basic post listing with title and date. If detailed post views are needed in the future, consider using a separate component or a different approach.

https://claude.ai/code/session_017UbmfHJTFyejnWU1zUeemU