### PR TITLE
Remove tag parsing logic from posts utility

### DIFF
--- a/src/lib/posts.ts
+++ b/src/lib/posts.ts
@@ -1,40 +1,6 @@
 import { getCollection } from "astro:content";
 import { format } from "date-fns";
 
-// Slugify function similar to @sindresorhus/slugify
-function slugify(str: string): string {
-  return str
-    .toLowerCase()
-    .trim()
-    .replace(/[^\w\s-]/g, "")
-    .replace(/[\s_-]+/g, "-")
-    .replace(/^-+|-+$/g, "");
-}
-
-// Parse comma-separated tags string into array of tag objects
-function parseTags(
-  tagsStr: string | undefined,
-  brandsStr?: string,
-  peepsStr?: string,
-  projectsStr?: string,
-): { label: string; slug: string }[] {
-  const allTags = [tagsStr, brandsStr, peepsStr, projectsStr].filter(Boolean).join(",");
-
-  if (!allTags) return [];
-
-  const tags = allTags
-    .split(",")
-    .map((tag) => tag.trim().toLowerCase())
-    .filter((tag) => tag.length > 0);
-
-  const uniqueTags = [...new Set(tags)];
-
-  return uniqueTags.map((tag) => ({
-    label: tag,
-    slug: `/tag/${slugify(tag)}/`,
-  }));
-}
-
 // Parse date and slug from post path
 // Pattern: /2022/03/17-demo/index.md -> date: 2022-03-17, slug: /2022-03-17-demo/
 function parsePostPath(id: string): { date: string; slug: string } {
@@ -74,7 +40,7 @@ export async function getAllPosts(): Promise<ProcessedPost[]> {
 
   const processPost = (entry: any, author: string): ProcessedPost => {
     const { date, slug } = parsePostPath(entry.id);
-    const tags = parseTags(entry.data.tags, entry.data.brands, entry.data.peeps, entry.data.projects);
+    const tags = entry.data.tags;
 
     const title = entry.data.title || "";
     const isRelatable = !title.includes("week around the Gatsby islands");


### PR DESCRIPTION
## Summary
Removed the `slugify` and `parseTags` helper functions from the posts utility module, simplifying the tag handling by using the raw tag data directly from post frontmatter.

## Changes
- Removed `slugify()` function that converted strings to URL-friendly slugs
- Removed `parseTags()` function that parsed comma-separated tag strings from multiple frontmatter fields (tags, brands, peeps, projects) and converted them to tag objects with labels and slugs
- Updated `getAllPosts()` to use `entry.data.tags` directly instead of processing it through `parseTags()`

## Details
This change assumes that:
1. Tag data is now pre-processed or comes in the expected format from the content collection
2. Tag slug generation and deduplication logic has been moved elsewhere or is no longer needed
3. The tags field in post frontmatter is already in the desired format (likely an array of tag objects with `label` and `slug` properties)

This simplification reduces code complexity in the posts utility and may indicate a shift in how tags are managed in the content layer.

https://claude.ai/code/session_016LaJhLBbtAHWxLtRbR5fy4